### PR TITLE
Gentoo build changes. 

### DIFF
--- a/src/BossaApp.cpp
+++ b/src/BossaApp.cpp
@@ -28,7 +28,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 #include "BossaApp.h"
 
-BossaApp::BossaApp() : config("Bossa")
+BossaApp::BossaApp() : config(wxT("Bossa"))
 {
 }
 

--- a/src/BossaInfo.cpp
+++ b/src/BossaInfo.cpp
@@ -36,9 +36,9 @@ BossaInfo::BossaInfo(wxWindow* parent) : InfoDialog(parent)
     Samba& samba = wxGetApp().samba;
     Flash::Ptr& flash = wxGetApp().flash;
 
-    _deviceTextCtrl->SetValue(flash->name().c_str());
+    _deviceTextCtrl->SetValue(wxString::FromUTF8(flash->name().c_str()));
     _chipIdTextCtrl->SetValue(wxString::Format(wxT("%08x"), samba.chipId()));
-    _versionTextCtrl->SetValue(samba.version().c_str());
+    _versionTextCtrl->SetValue(wxString::FromUTF8(samba.version().c_str()));
 
     _pagesTextCtrl->SetValue(wxString::Format(wxT("%d"), flash->numPages()));
     _pageSizeTextCtrl->SetValue(wxString::Format(wxT("%d bytes"), flash->pageSize()));

--- a/src/BossaThread.cpp
+++ b/src/BossaThread.cpp
@@ -191,11 +191,11 @@ WriteThread::Entry()
     {
         if (infile)
             fclose(infile);
-        Error(e.what());
+        Error(wxString::FromUTF8(e.what()));
         return 0;
     }
 
-    Success("Write completed successfully");
+    Success(wxT("Write completed successfully"));
     return 0;
 }
 
@@ -280,21 +280,21 @@ VerifyThread::Entry()
     {
         if (infile)
             fclose(infile);
-        Error(e.what());
+        Error(wxString::FromUTF8(e.what()));
         return 0;
     }
 
     if (byteErrors != 0)
     {
         Warning(wxString::Format(
-            "Verify failed\n"
-            "Page errors: %d\n"
-            "Byte errors: %d\n",
+            wxT("Verify failed\n")
+            wxT("Page errors: %d\n")
+            wxT("Byte errors: %d\n"),
             pageErrors, totalErrors));
         return 0;
     }
 
-    Success("Verify successful\n");
+    Success(wxT("Verify successful\n"));
 
     return 0;
 }
@@ -317,7 +317,7 @@ ReadThread::Entry()
     if (_size == 0)
         _size = pageSize * flash.numPages();
 
-    outfile = fopen(_filename, "wb");
+    outfile = fopen(_filename.mb_str(), "wb");
     if (!outfile)
         throw FileOpenError();
 
@@ -356,11 +356,11 @@ ReadThread::Entry()
     {
         if (outfile)
             fclose(outfile);
-        Error(e.what());
+        Error(wxString::FromUTF8(e.what()));
         return 0;
     }
 
-    Success("Read completed successfully");
+    Success(wxT("Read completed successfully"));
     return 0;
 }
 

--- a/src/BossaWindow.cpp
+++ b/src/BossaWindow.cpp
@@ -102,14 +102,14 @@ BossaWindow::BossaWindow() : MainFrame(NULL)
 
     wxString port;
     wxConfig& config = wxGetApp().config;
-    if (config.Read("Port", &port))
+    if (config.Read(wxT("Port"), &port))
     {
         if (_portComboBox->FindString(port) >= 0)
         {
             PortFactory& portFactory = wxGetApp().portFactory;
             Samba& samba = wxGetApp().samba;
 
-            if (samba.connect(portFactory.create(port.mb_str())))
+            if (samba.connect(portFactory.create((const char*) port.mb_str())))
             {
                 CreateFlash();
             }
@@ -117,7 +117,7 @@ BossaWindow::BossaWindow() : MainFrame(NULL)
     }
 
     wxString file;
-    if (config.Read("File", &file))
+    if (config.Read(wxT("File"), &file))
     {
         _filePicker->SetPath(file);
     }
@@ -133,8 +133,8 @@ BossaWindow::~BossaWindow()
 {
     wxConfig& config = wxGetApp().config;
 
-    config.Write("Port", _portComboBox->GetStringSelection());
-    config.Write("File", _filePicker->GetPath());
+    config.Write(wxT("Port"), _portComboBox->GetStringSelection());
+    config.Write(wxT("File"), _filePicker->GetPath());
 }
 
 void
@@ -149,7 +149,7 @@ BossaWindow::RefreshSerial()
          port != portFactory.end();
          port = portFactory.next())
     {
-        _portComboBox->Append(port.c_str());
+        _portComboBox->Append(wxString::FromUTF8(port.c_str()));
     }
 
     if (!_portComboBox->SetStringSelection(selection))
@@ -179,7 +179,7 @@ BossaWindow::Connected()
 
     _statusBar->SetStatusText(wxT("Connected"), 0);
     _statusBar->SetStatusText(wxString::Format(wxT("Device: %s"), flash.name().c_str()), 1);
-    _portComboBox->SetStringSelection(port.name().c_str());
+    _portComboBox->SetStringSelection(wxString::FromUTF8(port.name().c_str()));
     _bootCheckBox->Enable(flash.canBootFlash());
     _bodCheckBox->Enable(flash.canBod());
     _borCheckBox->Enable(flash.canBor());
@@ -193,7 +193,7 @@ void
 BossaWindow::Disconnected()
 {
     _statusBar->SetStatusText(wxT("Not connected"), 0);
-    _statusBar->SetStatusText("", 1);
+    _statusBar->SetStatusText(_T(""), 1);
     _portComboBox->SetSelection(wxNOT_FOUND);
     _writeButton->Enable(false);
     _verifyButton->Enable(false);
@@ -207,7 +207,7 @@ BossaWindow::Error(const wxString& message)
     wxMessageDialog* dialog = new wxMessageDialog(
         this,
         message,
-        "Error",
+        _T("Error"),
         wxOK | wxICON_ERROR
     );
     dialog->ShowModal();
@@ -220,7 +220,7 @@ BossaWindow::Warning(const wxString& message)
     wxMessageDialog* dialog = new wxMessageDialog(
         this,
         message,
-        "Warning",
+        _T("Warning"),
         wxOK | wxICON_WARNING
     );
     dialog->ShowModal();
@@ -233,7 +233,7 @@ BossaWindow::Info(const wxString& message)
     wxMessageDialog* dialog = new wxMessageDialog(
         this,
         message,
-        "Info",
+        _T("Info"),
         wxOK | wxICON_INFORMATION
     );
     dialog->ShowModal();
@@ -246,7 +246,7 @@ BossaWindow::Question(const wxString& message)
     wxMessageDialog* dialog = new wxMessageDialog(
         this,
         message,
-        "Question",
+        _T("Question"),
         wxYES_NO | wxICON_QUESTION
     );
     int resp = dialog->ShowModal();
@@ -270,7 +270,7 @@ BossaWindow::CreateFlash()
     catch (exception& e)
     {
         Disconnected();
-        Error(wxString(e.what()));
+        Error(wxString::FromUTF8(e.what()));
         return;
     }
 
@@ -293,10 +293,10 @@ BossaWindow::OnSerial(wxCommandEvent& event)
     Samba& samba = wxGetApp().samba;
 
     wxString port = _portComboBox->GetString(event.GetSelection());
-    if (!samba.connect(portFactory.create(port.mb_str())))
+    if (!samba.connect(portFactory.create((const char*) port.mb_str())))
     {
         Disconnected();
-        Error(wxString::Format(wxT("Could not connect to device on %s"), port.mb_str()));
+        Error(wxString::Format(wxT("Could not connect to device on %s"), (const char*) port.mb_str()));
         return;
     }
 
@@ -356,7 +356,7 @@ BossaWindow::OnWrite(wxCommandEvent& event)
     }
     catch(exception& e)
     {
-        Error(e.what());
+        Error(wxString::FromUTF8(e.what()));
         return;
     }
 
@@ -441,7 +441,7 @@ BossaWindow::OnRead(wxCommandEvent& event)
         size = strtol(_sizeTextCtrl->GetValue().mb_str(), NULL, 0);
         if (size == 0)
         {
-            Error("Read size is invalid");
+            Error(wxT("Read size is invalid"));
             return;
         }
     }
@@ -474,7 +474,7 @@ BossaWindow::OnInfo(wxCommandEvent& event)
     }
     catch (exception& e)
     {
-        Error(wxString(e.what()));
+        Error(wxString::FromUTF8(e.what()));
         return;
     }
 

--- a/src/CmdOpts.cpp
+++ b/src/CmdOpts.cpp
@@ -49,6 +49,7 @@ CmdOpts::usage(FILE* out)
     char name[40];
     const char* start;
     const char* end;
+    size_t wbytes;
 
     for (optIdx = 0; optIdx < _numOpts; optIdx++)
     {
@@ -72,7 +73,7 @@ CmdOpts::usage(FILE* out)
         start = _opts[optIdx].help;
         while ((end = strchr(start, '\n')))
         {
-            fwrite(start, end - start + 1, 1, out);
+            wbytes = fwrite(start, end - start + 1, 1, out);
             fprintf(out, "%24s", "");
             start = end + 1;
         }


### PR DESCRIPTION
I have little experience with C++ or wxWidgets but I was able to convince BOSSA to build on my system. If you could try out the changes against your own build environment and test functionality (I haven't tried working with my deRFusb with the tool yet, I needed a BA tool first) I'd be quite grateful. If you feel these changes aren't appropriate for mainline I'd be glad to continue maintaining it separately. Alternatively I could stuff these changes in a branch branch and keep it in your repo that way. 

Original code would not build on my Gentoo workstation with
wxGTK-2.8.12 due to ambiguous casting errors such as:

g++ -Wall -Werror -MT obj/BossaWindow.o -MD -MP -MF obj/BossaWindow.d
-DVERSION=\"1.2.1\" -g -O2
-I/usr/lib64/wx/include/gtk2-unicode-release-2.8 -I/usr/include/wx-2.8
-D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -D__WXGTK__ -pthread -DWX_PRECOMP
-Wno-ctor-dtor-privacy -O2 -fno-strict-aliasing  -c -o obj/BossaWindow.o
src/BossaWindow.cpp
src/BossaWindow.cpp: In constructor 'BossaWindow::BossaWindow()':
src/BossaWindow.cpp:105:34: error: conversion from 'const char [5]' to
'const wxString' is ambiguous
/usr/include/wx-2.8/wx/string.h:692:3: note: candidates are:
wxString::wxString(wxChar, size_t) <near match>
/usr/include/wx-2.8/wx/string.h:682:3: note:
wxString::wxString(int) <near match>
src/BossaWindow.cpp:112:63: error: no matching function for call to
'LinuxPortFactory::create(const wxCharBuffer)'
src/LinuxPortFactory.h:50:29: note: candidate is: virtual
SerialPort::Ptr LinuxPortFactory::create(const std::string&)
src/BossaWindow.cpp:120:34: error: conversion from 'const char [5]' to
'const wxString' is ambiguous
/usr/include/wx-2.8/wx/string.h:692:3: note: candidates are:
wxString::wxString(wxChar, size_t) <near match>
/usr/include/wx-2.8/wx/string.h:682:3: note:
wxString::wxString(int) <near match>

Through careful placement of various casts and conversions BOSSA
was made to build against wxGTK-2.8.12 and all 3 executables now
run but have not been tested functionality against any devices.