### PR TITLE
Added support for newer revisions of SAMD21G18A and created a common chip architecture ID method

### DIFF
--- a/src/FlashFactory.cpp
+++ b/src/FlashFactory.cpp
@@ -51,12 +51,14 @@ FlashFactory::create(Samba& samba, uint32_t chipId)
     // SAMD21
     //
     case 0x10010000:
-	case 0x10010100:
+    case 0x10010100:
         flash = new NvmFlash(samba, "ATSAMD21J18A", 0x000000, 4096, 64, 1, 16, 0x20004000, 0x20008000, 0x41004000, true);
         // 0x41004000 == Base address for the NVMCTRL module
         break;
-
+   
     case 0x10010005:
+    case 0x10010105:
+    case 0x10010205:
         flash = new NvmFlash(samba, "ATSAMD21G18A", 0x000000, 4096, 64, 1, 16, 0x20004000, 0x20008000, 0x41004000, true);
         break;
 

--- a/src/Samba.h
+++ b/src/Samba.h
@@ -76,6 +76,26 @@ public:
     void reset(void);
 
 private:
+    enum ChipArchitecture
+    {
+        Unsupported = 0,
+        SAM3U,
+        SAM3A,
+        SAM3X,
+        SAM3S,
+        SAM3SD,
+        SAM3N,
+        SAM7S,
+        SAM7XC,
+        SAM7SE,
+        SAM7L,
+        SAM7X,
+        SAM7SL,
+        SAM9XE,
+        SAMD20,
+        SAMD21
+    };
+
     bool _debug;
     bool _isUsb;
     SerialPort::Ptr _port;
@@ -90,6 +110,8 @@ private:
 
     void writeBinary(const uint8_t* buffer, int size);
     void readBinary(uint8_t* buffer, int size);
+
+    ChipArchitecture getChipArchitecture(uint32_t cid);
 
 };
 


### PR DESCRIPTION
The current code doesn't support the latest revisions of the SAMD21 (only Rev A supported).  This commit fixes that.

Also, identifying the chip family in Samba.cpp was a performed in a few places.  This commit centralizes that function to make it easier to maintain.