### PR TITLE
Adding support for the ATSAMD21E18A chip

### DIFF
--- a/src/Devices.h
+++ b/src/Devices.h
@@ -58,5 +58,16 @@
 #define ATSAMD21G18A_STACK_ADDR              (0x20008000ul)
 #define ATSAMD21G18A_NVMCTRL_BASE            (0x41004000ul)
 
+#define ATSAMD21E18A_NAME                    "ATSAMD21E18A"
+#define ATSAMD21E18A_CHIPID                  (0x1001000aul)  // DIE & REV bitfields masked in Samba::chipId()
+#define ATSAMD21E18A_FLASH_BASE              (0x00000000ul + ATSAMD_BOOTLOADER_SIZE)
+#define ATSAMD21E18A_FLASH_PAGE_SIZE         (64ul)
+#define ATSAMD21E18A_FLASH_PAGES             (4096ul)
+#define ATSAMD21E18A_FLASH_PLANES            (1ul)
+#define ATSAMD21E18A_FLASH_LOCK_REGIONS      (16ul)
+#define ATSAMD21E18A_BUFFER_ADDR             (0x20004000ul)
+#define ATSAMD21E18A_STACK_ADDR              (0x20008000ul)
+#define ATSAMD21E18A_NVMCTRL_BASE            (0x41004000ul)
+
 
 #endif // _DEVICES_H_

--- a/src/FlashFactory.cpp
+++ b/src/FlashFactory.cpp
@@ -63,6 +63,12 @@ FlashFactory::create(Samba& samba, uint32_t chipId)
                               ATSAMD21G18A_BUFFER_ADDR, ATSAMD21G18A_STACK_ADDR, ATSAMD21G18A_NVMCTRL_BASE, /*canBrownout*/true ) ;
         break ;
 
+    case ATSAMD21E18A_CHIPID:
+        flash = new NvmFlash( samba, ATSAMD21E18A_NAME, ATSAMD21E18A_FLASH_BASE, ATSAMD21E18A_FLASH_PAGES, ATSAMD21E18A_FLASH_PAGE_SIZE,
+                              ATSAMD21E18A_FLASH_PLANES, ATSAMD21E18A_FLASH_LOCK_REGIONS,
+                              ATSAMD21E18A_BUFFER_ADDR, ATSAMD21E18A_STACK_ADDR, ATSAMD21E18A_NVMCTRL_BASE, /*canBrownout*/true ) ;
+        break ;
+
     //
     // SAM7SE
     //

--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -145,7 +145,8 @@ Samba::init()
             printf("Unsupported ARM920T architecture\n");
     }
     // Check for supported M0+ processor
-	else if (cid == 0x10010000 || cid == 0x10010100 || cid == 0x10010005)
+    // NOTE: 0x1001000a is a ATSAMD21E18A
+	else if (cid == 0x10010000 || cid == 0x10010100 || cid == 0x10010005 || cid == 0x1001000a)
     {
         return true;
     }


### PR DESCRIPTION
I'd like to enable support for the ATSAMD21E18A. Support for the SAMD21G18A and SAMD21J18A is already present within this branch. Since the SAMD21E18A essentially uses the same device and flash settings, it's a matter of simply adding in the correct constants and ID check.