### PR TITLE
Restore termios settings after using serial port

### DIFF
--- a/src/PosixSerialPort.h
+++ b/src/PosixSerialPort.h
@@ -29,6 +29,7 @@
 #ifndef _POSIXSERIALPORT_H
 #define _POSIXSERIALPORT_H
 
+#include <termios.h>
 #include "SerialPort.h"
 
 class PosixSerialPort : public SerialPort
@@ -59,6 +60,8 @@ private:
     bool _isUsb;
     int _timeout;
     bool _autoFlush;
+    struct termios _original_settings;
+    bool _original_settings_saved;
 };
 
 #endif // _POSIXSERIALPORT_H

--- a/src/bossac.cpp
+++ b/src/bossac.cpp
@@ -379,6 +379,8 @@ main(int argc, char* argv[])
 
         if (config.reset)
             samba.reset();
+
+        samba.disconnect();
     }
     catch (exception& e)
     {


### PR DESCRIPTION
This fixes problem where bossac would leave serial port configured to
115200 baud, even if isn't system's default setting. Such behavior
interferes with other serial port users (eg. Arduino bridge.py)