### PR TITLE
Added support for SAM4S2 and SAM4S4 processors. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,8 @@ ARMOBJCOPY=$(ARM)objcopy
 #
 # CXX Flags
 #
-COMMON_CXXFLAGS+=-Wall -Werror -MT $@ -MD -MP -MF $(@:%.o=%.d) -DVERSION=\"$(VERSION)\" -g -O2
+# COMMON_CXXFLAGS+=-Wall -Werror -MT $@ -MD -MP -MF $(@:%.o=%.d) -DVERSION=\"$(VERSION)\" -g -O2
+COMMON_CXXFLAGS+=-Wall -MT $@ -MD -MP -MF $(@:%.o=%.d) -DVERSION=\"$(VERSION)\" -g -O2
 WX_CXXFLAGS:=$(shell wx-config --cxxflags --version=$(WXVERSION)) -DWX_PRECOMP -Wno-ctor-dtor-privacy -O2 -fno-strict-aliasing
 BOSSA_CXXFLAGS=$(COMMON_CXXFLAGS) $(WX_CXXFLAGS)
 BOSSAC_CXXFLAGS=$(COMMON_CXXFLAGS)

--- a/src/FlashFactory.cpp
+++ b/src/FlashFactory.cpp
@@ -152,6 +152,14 @@ FlashFactory::create(Samba& samba, uint32_t chipId)
     case 0x28ac0ae1 : // C
         flash = new EefcFlash(samba, "ATSAM4S8", 0x400000, 1024, 512, 1, 64, 0x20001000, 0x20020000, 0x400e0a00, false);
         break;
+    case 0x288b09e0 : // A
+    case 0x288b09e1 : // A
+    case 0x289b09e0 : // B
+    case 0x289b09e1 : // B
+    case 0x28ab09e0 : // C
+    case 0x28ab09e1 : // C
+        flash = new EefcFlash(samba, "ATSAM4S4", 0x400000, 512, 512, 1, 16, 0x20001000, 0x20010000, 0x400e0a00, false);
+		break;
     case 0x288b07e0 : // A
     case 0x288b07e1 : // A
     case 0x289b07e0 : // B

--- a/src/FlashFactory.cpp
+++ b/src/FlashFactory.cpp
@@ -139,14 +139,28 @@ FlashFactory::create(Samba& samba, uint32_t chipId)
     case 0x288c0ce0 : // A
     case 0x289c0ce0 : // B
     case 0x28ac0ce0 : // C
+	case 0x288c0ce1 : // A
+    case 0x289c0ce1 : // B
+    case 0x28ac0ce1 : // C
         flash = new EefcFlash(samba, "ATSAM4S16", 0x400000, 2048, 512, 1, 128, 0x20001000, 0x20020000, 0x400e0a00, false);
         break;
     case 0x288c0ae0 : // A
     case 0x289c0ae0 : // B
     case 0x28ac0ae0 : // C
+	case 0x288c0ae1 : // A
+    case 0x289c0ae1 : // B
+    case 0x28ac0ae1 : // C
         flash = new EefcFlash(samba, "ATSAM4S8", 0x400000, 1024, 512, 1, 64, 0x20001000, 0x20020000, 0x400e0a00, false);
         break;
-    //
+	case 0x288b07e0 : // A
+	case 0x288b07e1 : // A
+	case 0x289b07e0 : // B
+	case 0x289b07e1 : // B
+	case 0x28ab07e0 : // C
+	case 0x28ab07e1 : // C
+		flash = new EefcFlash(samba, "ATSAM4S2", 0x400000, 256, 512, 1, 16, 0x20001000, 0x20010000, 0x400e0a00, false);
+		break;
+	//
     // SAM3N
     //
     case 0x29340960 : // A

--- a/src/FlashFactory.cpp
+++ b/src/FlashFactory.cpp
@@ -139,7 +139,7 @@ FlashFactory::create(Samba& samba, uint32_t chipId)
     case 0x288c0ce0 : // A
     case 0x289c0ce0 : // B
     case 0x28ac0ce0 : // C
-	case 0x288c0ce1 : // A
+    case 0x288c0ce1 : // A
     case 0x289c0ce1 : // B
     case 0x28ac0ce1 : // C
         flash = new EefcFlash(samba, "ATSAM4S16", 0x400000, 2048, 512, 1, 128, 0x20001000, 0x20020000, 0x400e0a00, false);
@@ -147,18 +147,18 @@ FlashFactory::create(Samba& samba, uint32_t chipId)
     case 0x288c0ae0 : // A
     case 0x289c0ae0 : // B
     case 0x28ac0ae0 : // C
-	case 0x288c0ae1 : // A
+    case 0x288c0ae1 : // A
     case 0x289c0ae1 : // B
     case 0x28ac0ae1 : // C
         flash = new EefcFlash(samba, "ATSAM4S8", 0x400000, 1024, 512, 1, 64, 0x20001000, 0x20020000, 0x400e0a00, false);
         break;
-	case 0x288b07e0 : // A
-	case 0x288b07e1 : // A
-	case 0x289b07e0 : // B
-	case 0x289b07e1 : // B
-	case 0x28ab07e0 : // C
-	case 0x28ab07e1 : // C
-		flash = new EefcFlash(samba, "ATSAM4S2", 0x400000, 256, 512, 1, 16, 0x20001000, 0x20010000, 0x400e0a00, false);
+    case 0x288b07e0 : // A
+    case 0x288b07e1 : // A
+    case 0x289b07e0 : // B
+    case 0x289b07e1 : // B
+    case 0x28ab07e0 : // C
+    case 0x28ab07e1 : // C
+        flash = new EefcFlash(samba, "ATSAM4S2", 0x400000, 256, 512, 1, 16, 0x20001000, 0x20010000, 0x400e0a00, false);
 		break;
 	//
     // SAM3N

--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -158,6 +158,15 @@ Samba::init()
         if (_debug)
             printf("Unsupported Cortex-M3 architecture\n");
     }
+	// Check for Cortex-M4 processor
+	else if (eproc == 7)
+	{
+		// Check for SAM4 architecture
+        if (arch >= 0x88 && arch <= 0x8a)
+            return true;
+		if (_debug)
+			printf("Unsupported Cortex-M4 architecture\n");
+	}
     // Check for ARM920T processor
     else if (eproc == 4)
     {

--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -158,15 +158,15 @@ Samba::init()
         if (_debug)
             printf("Unsupported Cortex-M3 architecture\n");
     }
-	// Check for Cortex-M4 processor
-	else if (eproc == 7)
-	{
-		// Check for SAM4 architecture
+    // Check for Cortex-M4 processor
+    else if (eproc == 7)
+    {
+        // Check for SAM4 architecture
         if (arch >= 0x88 && arch <= 0x8a)
             return true;
-		if (_debug)
-			printf("Unsupported Cortex-M4 architecture\n");
-	}
+        if (_debug)
+            printf("Unsupported Cortex-M4 architecture\n");
+    }
     // Check for ARM920T processor
     else if (eproc == 4)
     {


### PR DESCRIPTION
Pretty much does what it says in the title. I also had to modify the Makefile to remove -Werror, because my mingw setup calls that out as deprecated. While I was mucking around, I also added appropriate cases for rev B of the supported SAM4S chips. 