### PR TITLE
Allow full path in PosixSerialPort constructor

### DIFF
--- a/src/PosixSerialPort.cpp
+++ b/src/PosixSerialPort.cpp
@@ -65,12 +65,17 @@ PosixSerialPort::open(int baud,
 {
     struct termios options;
     speed_t speed;
-    std::string dev("/dev/");
-
-    dev += _name;
-    _devfd = ::open(dev.c_str(), O_RDWR | O_NOCTTY | O_NDELAY);
+    // Try opening port assuming _name is full path. If it fails
+    // try "/dev/" + _name
+    _devfd = ::open(_name.c_str(), O_RDWR | O_NOCTTY | O_NDELAY);
     if (_devfd == -1)
-        return false;
+    {
+        std::string dev("/dev/");
+        dev += _name;
+        _devfd = ::open(dev.c_str(), O_RDWR | O_NOCTTY | O_NDELAY);
+        if (_devfd == -1)
+            return false;
+    }
 
     if (tcgetattr(_devfd, &options) == -1)
     {


### PR DESCRIPTION
Was previously using '/dev/' + name. Now tries name, reverting to '/dev/'+name if name can't be opened.