### PR TITLE
Arduino Sketch uploads for SAM R21 - Corrected Bootloader Size, addendum to README

### DIFF
--- a/README
+++ b/README
@@ -20,3 +20,27 @@ RELEASE NOTES
 * Some stability issues have been seen with the OS X USB driver using BOSSA.  When running BOSSA a second time to the same Atmel device, the USB driver can lock up causing BOSSA to freeze.  As a workaround, always disconnect and reconnect the Atmel device before running BOSSA again.
 * The firmware inside of SAM3U devices has a bug where non-word flash reads return zero instead of the real data.  BOSSA implements a transparent workaround for flash operations that copies flash to SRAM before reading.  Direct reads using the BOSSA shell will see the bug.
 * There are reports that the USB controller in some AMD-based systems has difficulty communicating with SAM devices.  The only known workaround is to use a different, preferrably Intel-based, system.
+
+
+How To Compile on Linux (Ubuntu)
+--------------------------------
+Make sure you have the 'build-essentials' package installed.
+```
+sudo apt-get install build-essentials
+```
+
+You will also need libreadline-dev, and the wxWidgets libraries.
+```
+sudo apt-get install libreadline-dev wx2.8-headers libwxgtk2.8-0 libwxgtk2.8-dev
+```
+
+Now, from the top most directory of the BOSSA checkout, run the following in your bash terminal.
+```
+# Compile the 'bossa' CLI source into the bin folder, use up to four jobs while compiling
+make bin/bossac -j4
+```
+
+```
+# Compile the 'bossa' shell source into the bin folder, use up to four jobs while compiling
+make bin/bossash -j4
+```

--- a/src/Devices.h
+++ b/src/Devices.h
@@ -34,7 +34,7 @@
 
 #define ATSAMD_CHIPID_MASK                   (0xFFFF00FFul)  // mask for DIE & REV bitfields removal in Samba::chipId()
 #define ATSAMD_BOOTLOADER_SIZE               (0x00002000ul)  // 8192 bytes
-#define ATSAMR_BOOTLOADER_SIZE               (0x00001000ul) // 4096 bytes, USB-CDC only
+#define ATSAMR_BOOTLOADER_SIZE               (0x00002000ul) // 8192 bytes, USB-CDC only
 #define ATSAMD_FLASH_ROW_PAGES               (4ul)           // 4 pages per row
 
 #define ATSAMD21J18A_NAME                    "ATSAMD21J18A"

--- a/src/Devices.h
+++ b/src/Devices.h
@@ -70,7 +70,7 @@
 #define ATSAMD21E18A_STACK_ADDR              (0x20008000ul)
 #define ATSAMD21E18A_NVMCTRL_BASE            (0x41004000ul)
 
-#define ATSAMR21E18A_NAME                    "ATSAMDR1E18A"
+#define ATSAMR21E18A_NAME                    "ATSAMR1E18A"
 #define ATSAMR21E18A_CHIPID                  (0x1001001cul)  // DIE & REV bitfields masked in Samba::chipId()
 #define ATSAMR21E18A_FLASH_BASE              (0x00000000ul + ATSAMR_BOOTLOADER_SIZE)
 #define ATSAMR21E18A_FLASH_PAGE_SIZE         (64ul)

--- a/src/Devices.h
+++ b/src/Devices.h
@@ -70,7 +70,7 @@
 #define ATSAMD21E18A_STACK_ADDR              (0x20008000ul)
 #define ATSAMD21E18A_NVMCTRL_BASE            (0x41004000ul)
 
-#define ATSAMR21E18A_NAME                    "ATSAMR1E18A"
+#define ATSAMR21E18A_NAME                    "ATSAMR21E18A"
 #define ATSAMR21E18A_CHIPID                  (0x1001001cul)  // DIE & REV bitfields masked in Samba::chipId()
 #define ATSAMR21E18A_FLASH_BASE              (0x00000000ul + ATSAMR_BOOTLOADER_SIZE)
 #define ATSAMR21E18A_FLASH_PAGE_SIZE         (64ul)


### PR DESCRIPTION
This pull request includes the corrected bootloader size for SAM R21 (was 0x1000, correct value is 0x2000), and a brief set of instructions for folks who would like to compile BOSSA on their machine.