### PR TITLE
Add support for Atmel SAM3N0A/B chips.

### DIFF
--- a/src/FlashFactory.cpp
+++ b/src/FlashFactory.cpp
@@ -186,6 +186,10 @@ FlashFactory::create(Samba& samba, uint32_t chipId)
     case 0x29580560 : // C
         flash = new EefcFlash(samba, "ATSAM3N1", 0x400000, 256, 256, 1, 4, 0x20000800, 0x20002000, 0x400e0a00, false);
         break;
+    case 0x29380361 : // A
+    case 0x29480361 : // B
+        flash = new EefcFlash(samba, "ATSAM3N0", 0x400000, 128, 256, 1, 2, 0x20000800, 0x20002000, 0x400e0a00, false);
+        break;
     //
     // SAM3S
     //


### PR DESCRIPTION
This adds support for SAM3N0A/B chips. I've only tested it with a SAM3N0A, but I see no reason it won't transparently work for SAM3N0B as well.

I thought about adding in the SAM3N00-series chips, but I don't have one locally to test the programmer with so was not comfortable with doing so.