### PR TITLE
Fix for issue #43 - add compiler flag for std c++ version on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ endif
 ifeq ($(OS),Linux)
 COMMON_SRCS+=PosixSerialPort.cpp LinuxPortFactory.cpp
 COMMON_LIBS=-Wl,--as-needed
+COMMON_CXXFLAGS=-std=c++11
 WX_LIBS+=-lX11
 
 MACHINE:=$(shell uname -m)


### PR DESCRIPTION
- adds -std=c++11 CXX flag when building on linux
- was getting this from SerialPort.h 'error: ‘unique_ptr’ in namespace ‘std’ does not name a
  template type'

Assumes c++11 instead of c++14.  Also assumes this is only needed on linux.