### PR TITLE
Samba.cpp reset: Add SAM4E support, catch thrown exception

### DIFF
--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -678,25 +678,35 @@ Samba::reset(void)
     uint32_t extChipId;
     
     Samba::chipId(chipId, extChipId);
-
-    switch (chipId)
-    {
-    case 0x10010000:
-    case 0x10010005:
-    case 0x1001000a:
-    case 0x1001001c:
-        // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0484c/index.html
-        writeWord(0xE000ED0C, 0x05FA0004);
-        break;
-
-    // SAM3X8E
-    case 0x285e0a60:
-        writeWord(0x400E1A00, 0xA500000D);
-        break;
-
-    default:
-        printf("Reset not supported for this CPU.\n");
-        return;
+	
+	try
+	{
+	    switch (chipId)
+	    {
+	    case 0x10010000:
+	    case 0x10010005:
+	    case 0x1001000a:
+	    case 0x1001001c:
+	        // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0484c/index.html
+	        writeWord(0xE000ED0C, 0x05FA0004);
+	        break;
+	
+	    // SAM3X8E
+	    case 0x285e0a60:
+	        writeWord(0x400E1A00, 0xA500000D);
+	        break;
+	    // SAM4E
+	    case 0xa3cc0ce0:
+	        writeWord(0x400E1800, 0xA500000D);
+	        break;
+	
+	    default:
+	        printf("Reset not supported for this CPU.\n");
+	        return;
+	    }
+	}
+	catch (exception& expected)
+    {	// writeWord will most likely throw an exception when the CPU is reset
     }
 }
 


### PR DESCRIPTION
Dear schumatech,

Thanks for this awesome project - it is such a useful little tool for people using the SAM-BA bootloader. This PR has 2 little improvements to the reset feature. I think catching the exception (which will always occur if the native USB connection is used) is justified otherwise a completely successful BOSSA operation can return an "error".

Commit message:
Catch exception in samba.cpp reset which is very likely to be thrown because the serial connection breaks when the CPU is reset.
Add reset support for SAM4E.