### PR TITLE
Fix BSD build 

### DIFF
--- a/src/BSDPortFactory.cpp
+++ b/src/BSDPortFactory.cpp
@@ -96,6 +96,11 @@ BSDPortFactory::next()
 std::string
 BSDPortFactory::end()
 {
-    return std::string("/dev/cuaU0");
+    return std::string();
 }
 
+std::string
+BSDPortFactory::def()
+{
+    return std::string("/dev/cuaU0");
+}


### PR DESCRIPTION
Breakage seems to be a result of a typo, restore BSDPortFactory::end() to pre- ee5a651 behavior and add BSDPortFactory::def()