### PR TITLE
SAML21G18 Support

### DIFF
--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -324,6 +324,11 @@ Device::create()
             _family = FAMILY_SAMD21;
             flashPtr = new NvmFlash( _samba, "ATSAMD21x18", 0x2000, 4096, 64, 1, 16, 0x20004000, 0x20008000, 0x41004000, true ) ;
             break;
+        case 0x10810019:
+        case 0x10810014:
+            _family = FAMILY_SAML21;
+            flashPtr = new NvmFlash( _samba, "ATSAML21x18", 0x6000, 4096, 64, 1, 16, 0x20004000, 0x20008000, 0x41004000, true ) ;
+            break;
 
         case 0x1001001c:
         case 0x10010019:
@@ -354,6 +359,7 @@ Device::reset(void)
     switch (_family)
     {
     case FAMILY_SAMD21:
+    case FAMILY_SAML21:
     case FAMILY_SAMR21:
         _samba.writeWord(0xE000ED0C, 0x05FA0004);
         break;

--- a/src/Device.h
+++ b/src/Device.h
@@ -65,6 +65,7 @@ public:
         FAMILY_SAM9XE,
 
         FAMILY_SAMD21,
+        FAMILY_SAML21,
         FAMILY_SAMR21,
     };
 

--- a/src/NvmFlash.cpp
+++ b/src/NvmFlash.cpp
@@ -98,9 +98,6 @@ NvmFlash::~NvmFlash()
 }
 
 const int
-NvmFlash::bootloaderSize = 0x2000;
-
-const int
 NvmFlash::flashRowPages = 4;
 
 void
@@ -117,7 +114,7 @@ NvmFlash::eraseAll()
     }
 
     // Calculate the number of rows that samba occupies (should be 32 for 8KB/0x2000bytes).
-    uint32_t starting_row = bootloaderSize / _size / flashRowPages;
+    uint32_t starting_row = _addr/ _size / flashRowPages;
     uint32_t total_rows = _pages / flashRowPages;
 
     for (uint32_t row=starting_row; row<total_rows; row++)

--- a/src/NvmFlash.h
+++ b/src/NvmFlash.h
@@ -51,7 +51,7 @@ public:
 
     virtual ~NvmFlash();
 
-    virtual uint32_t numPages() { return _pages - bootloaderSize / pageSize(); }
+    virtual uint32_t numPages() { return _pages - _addr/ pageSize(); }
 
     void eraseAll();
     void eraseAuto(bool enable);
@@ -78,7 +78,6 @@ public:
     void writePage(uint32_t page);
     void readPage(uint32_t page, uint8_t* data);
 
-    static const int bootloaderSize;
     static const int flashRowPages;
 
 private:


### PR DESCRIPTION
Support for SAML21G18.  Other SAML21 devices can be supported by checking for additional deviceIDs.  

I have a SAML21G18 dev board I can send for regression testing.
