### PR TITLE
Added support for SAME70Q21

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Supported Device Families
  * SAM7L\*
  * SAM9XE\*
  * SAMD21\*
+ * SAME70Q21\*
 
 \* Device families which are not tested for each release and could stop working.
 

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -55,7 +55,7 @@ Device::create()
     {
         deviceId = _samba.readWord(0x41002018);
     }
-    // Assume we have a SAM3 and SAM4 so check the CHIPID registers
+    // Assume we have a SAM3, SAM4 or SAME7 so check the CHIPID registers
     else if ((chipId = _samba.readWord(0x400e0740)) != 0)
     {
         extChipId = _samba.readWord(0x400e0744);
@@ -291,7 +291,6 @@ Device::create()
         _family = FAMILY_SAM9XE;
         flashPtr = new EefcFlash(_samba, "ATSAM9XE128", 0x200000, 256, 512, 1, 8, 0x300000, 0x303000, 0xfffffa00, true);
         break;
-
     //
     // SAM4E
     //
@@ -310,7 +309,13 @@ Device::create()
             break;
         }
         break;
-
+	//
+	// SAME70Q21
+	//
+	case 0x21020e00:
+		_family = FAMILY_SAME70;
+		flashPtr = new EefcFlash(_samba, "ATSAME70Q21", 0x400000, 4096, 512, 1, 128, 0x20401000, 0x20401040, 0x400e0c00, false);
+		break;
     //
     // No CHIPID devices
     //

--- a/src/Device.h
+++ b/src/Device.h
@@ -66,6 +66,8 @@ public:
 
         FAMILY_SAMD21,
         FAMILY_SAMR21,
+
+		FAMILY_SAME70
     };
 
     Device(Samba& samba) : _samba(samba), _flash(nullptr), _family(FAMILY_NONE) {}

--- a/src/EefcFlash.cpp
+++ b/src/EefcFlash.cpp
@@ -72,7 +72,7 @@ EefcFlash::EefcFlash(Samba& samba,
       _regs(regs), _canBrownout(canBrownout), _eraseAuto(true)
 {
     assert(planes == 1 || planes == 2);
-    assert(pages <= 2048);
+    assert(pages <= 4096);
     assert(lockRegions <= 256);
 
     // SAM3 Errata (FWS must be 6)


### PR DESCRIPTION
This version adds support for the SAME70Q21 chip as used on the SAME70 XPLD board. The changes have been tested and are working well.