### PR TITLE
Fixing macOS compilation error

### DIFF
--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -33,6 +33,7 @@
 #include <stdint.h>
 #include <ctype.h>
 #include <unistd.h>
+#include <errno.h>
 
 using namespace std;
 

--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -31,6 +31,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <ctype.h>
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
- Missing errno.h

```
src/Samba.cpp:662:20: error: use of undeclared identifier 'strtol'; did you mean 'stol'?
    uint32_t res = strtol((char*) &cmd[1], NULL, 16);
                   ^~~~~~
                   stol
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:4106:37: note: 'stol' declared here
_LIBCPP_FUNC_VIS long               stol  (const string& __str, size_t* __idx = 0, int __base = 10);
                                    ^
src/Samba.cpp:663:9: error: use of undeclared identifier 'errno'
    if (errno != 0)
```

- Missing stdlib.h

```
src/Samba.cpp:663:20: error: use of undeclared identifier 'strtol'; did you mean 'stol'?
    uint32_t res = strtol((char*) &cmd[1], NULL, 16);
                   ^~~~~~
                   stol
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/string:4106:37: note: 'stol' declared here
_LIBCPP_FUNC_VIS long               stol  (const string& __str, size_t* __idx = 0, int __base = 10);
```