### PR TITLE
Adding Travis-CI build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,74 @@
+# travis-ci integration for BOSSA
+# Jacob Alexander 2018
+
+sudo: required
+
+# Language
+language:
+  - cpp
+
+# OS
+os:
+  - linux
+  - osx
+
+# Environment Variables
+env:
+  global:
+    - VERSION=${TRAVIS_TAG}
+
+# Package Setup
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install tree libwxgtk3.0-dev libreadline-dev -y; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install tree wxmac; fi
+
+# System setup
+install:
+  # Info about OS
+  - uname -a
+
+  # Directory tree to validate kll.git
+  - tree
+
+  # Compiler Version
+  - ${CC} --version
+
+# Run build command
+script:
+  - make -j && make install
+
+# Setup Deploy
+before_deploy:
+  - mkdir -p deploy
+
+  # Copy files for deployment
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cp bin/*.tgz deploy/.; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cp bin/*.dmg deploy/.; fi
+  - if [[ "$SCRIPT" == "ic_keyboards.bash" ]]; then for f in Keyboards/firmware/*.dfu.bin; do cp -f ${f} deploy/${TRAVIS_TAG}.$(basename ${f}); done; fi
+  - if [[ "$SCRIPT" == "all.bash" ]]; then for f in Bootloader/Builds/bootloader/*.bootloader.bin; do cp -f ${f} deploy/${TRAVIS_TAG}.$(basename ${f}); done; fi
+
+  # Show files being deployed
+  - tree deploy
+
+# Deploy release
+deploy:
+  name: ${TRAVIS_TAG}
+  tag_name: ${TRAVIS_TAG}
+  provider: releases
+  api_key: $GITHUB_OAUTH_TOKEN
+  target_commitish: ${TRAVIS_COMMIT}
+  skip_cleanup: true
+  prerelease: true # XXX Set this to false to enable a stable release
+  file_glob: true
+  overwrite: true
+  file: deploy/*
+  on:
+    tags: true
+
+# Post test script commands
+after_script:
+  - bin/bossac --help
+  - tree
+

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 # Version
 #
-VERSION=1.9
+VERSION?=1.9
 WXVERSION=3.0
 
 #


### PR DESCRIPTION
- Linux and macOS build support (64-bit)
- Basic GitHub deployment based on tag name
- Build version can be modified using the git tag

You'll need to setup two things to use this integration.
- [Travis-CI](https://travis-ci.org/) with shumatech/BOSSA - This enables builds
- Add an environment variable to Settings (e.g. https://travis-ci.org/shumatech/BOSSA/settings) `GITHUB_OAUTH_TOKEN` with a `public_repo` key (https://github.com/settings/tokens) - This enables GitHub release auto-deployment for macOS and Linux.

I'm still having difficulties building on Windows with Appveyor, but I'll open another PR if I get that working.