### PR TITLE
wait after Arduino 1200 baud reset to allow chip to reboot and re-enumerate

### DIFF
--- a/src/bossac.cpp
+++ b/src/bossac.cpp
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 #include "CmdOpts.h"
 #include "Samba.h"
@@ -358,6 +359,7 @@ main(int argc, char* argv[])
             SerialPort::Ptr port;
             port = portFactory.create(config.portArg, config.usbPortArg != 0);
 
+            printf("Arduino 1200 baud reset\n");
             if(!port->open(1200))
             {
                 fprintf(stderr, "Failed to open port at 1200bps\n");
@@ -367,6 +369,12 @@ main(int argc, char* argv[])
             port->setRTS(true);
             port->setDTR(false);
             port->close();
+
+            // wait for chip to reboot and USB port to re-appear
+            sleep(1);
+
+            if (config.debug)
+                printf("Arduino reset done\n");
         }
 
         if (config.portArg.empty())


### PR DESCRIPTION
In the latest 1.6.18 Arduino core, there's a 250ms reset delay during
which touching the serial port again will cancel the reset, so we must
wait at least that long or the bootloader reset will fail [1].

We also need to wait a bit longer for the chip to reboot and the USB
serial port to re-appear, or else bossa will fail to open it for SAM-BA.

In my testing, 500ms is too short, but 1s works consistently.

[1] https://github.com/arduino/ArduinoCore-samd/blob/1.6.18/cores/arduino/USB/CDC.cpp#L123

Signed-off-by: Allen Wild <allenwild93@gmail.com>