### PR TITLE
Fix unlock and erase for `bossac`

### DIFF
--- a/src/bossac.cpp
+++ b/src/bossac.cpp
@@ -402,7 +402,12 @@ main(int argc, char* argv[])
         }
 
         if (config.unlock)
+        {
+            timer_start();
             flasher.lock(config.unlockArg, false);
+            flash->writeOptions();
+            printf("\nDone in %5.3f seconds\n", timer_stop());
+        }        
 
         if (config.erase)
         {


### PR DESCRIPTION
Previously, for a locked device, `bossac` would fail if you passed both an `--unlock` and an `--erase` flag at the same time, as the erase was scheduled before the unlocking. This PR enforces that any `--unlock` operation is committed immediately, so that any following erase or write operation can succeed.