### PR TITLE
Add failure description (from errno) when failing to open device

### DIFF
--- a/src/BossaWindow.cpp
+++ b/src/BossaWindow.cpp
@@ -280,10 +280,12 @@ BossaWindow::OnSerial(wxCommandEvent& event)
     Samba& samba = wxGetApp().samba;
 
     wxString port = _portComboBox->GetString(event.GetSelection());
+    errno = 0;
+
     if (!samba.connect(portFactory.create(std::string(port.mb_str()))))
     {
         Disconnected();
-        Error(wxString::Format(_("Could not connect to device on %s"), port.c_str()));
+        Error(wxString::Format(_("Could not connect to device on %s: %s"), port.c_str(), strerror(errno)));
         return;
     }
 

--- a/src/PosixSerialPort.cpp
+++ b/src/PosixSerialPort.cpp
@@ -32,9 +32,7 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <termios.h>
-#include <errno.h>
 #include <sys/ioctl.h>
 
 #include <string>


### PR DESCRIPTION
Maybe I should throw an FileOpenError instead? Anyway, not having this error message cost me 30 minutes today and I don't want anyone else feel as stupid as I did when I noticed it was a permission problem.