### PR TITLE
Add a delay to Arduino erase section

### DIFF
--- a/src/bossac.cpp
+++ b/src/bossac.cpp
@@ -33,6 +33,8 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <sys/time.h>
+#include <chrono>
+#include <thread>
 
 #include "CmdOpts.h"
 #include "Samba.h"
@@ -367,6 +369,7 @@ main(int argc, char* argv[])
             port->setRTS(true);
             port->setDTR(false);
             port->close();
+            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
         }
 
         if (config.portArg.empty())


### PR DESCRIPTION
This way Bossac doesn't hold the serialport while the bootloader loads.

I found that without the delay a new serailport gets assigned. For
example starting an upload (with the -a flag) to /dev/ttyACM0 resets
into the bootloader. But then the bootloader gets assigned /dev/ttyACM1.