### PR TITLE
Build compatibility for MSVC++ 2017

### DIFF
--- a/src/BossaProgress.cpp
+++ b/src/BossaProgress.cpp
@@ -44,7 +44,7 @@ void
 BossaProgress::SetValue(int pos)
 {
     _statusGauge->SetValue(pos);
-#if __WIN32
+#if defined(__WIN32__) || defined(WIN32)
     // Work around slow update on Windows
     _statusGauge->SetValue(pos - 1);
     _statusGauge->SetValue(pos);

--- a/src/Driver.h
+++ b/src/Driver.h
@@ -42,7 +42,7 @@ public:
     virtual bool update() = 0;
 };
 
-#ifdef __WIN32__
+#if defined(__WIN32__) || defined(WIN32)
 #include "WinDriver.h"
 typedef WinDriver Driver;
 #else

--- a/src/EefcFlash.cpp
+++ b/src/EefcFlash.cpp
@@ -29,8 +29,12 @@
 #include "EefcFlash.h"
 
 #include <assert.h>
-#include <unistd.h>
 #include <stdio.h>
+#if defined(__WIN32__) || defined(WIN32)
+#include "usleep.h"
+#else
+#include <unistd.h>
+#endif
 
 #define EEFC_KEY        0x5a
 

--- a/src/EfcFlash.cpp
+++ b/src/EfcFlash.cpp
@@ -29,8 +29,12 @@
 #include "EfcFlash.h"
 
 #include <assert.h>
-#include <unistd.h>
 #include <stdio.h>
+#if defined(__WIN32__) || defined(WIN32)
+#include "usleep.h"
+#else
+#include <unistd.h>
+#endif
 
 #define EFC_KEY         0x5a
 

--- a/src/Flasher.cpp
+++ b/src/Flasher.cpp
@@ -112,19 +112,19 @@ Flasher::write(const char* filename, uint32_t foffset)
         {
             uint32_t offset = 0;
             uint32_t bufferSize = _samba.writeBufferSize();
-            uint8_t buffer[bufferSize];
+            std::vector<uint8_t> buffer(bufferSize);
             
-            while ((fbytes = fread(buffer, 1, bufferSize, infile)) > 0)
+            while ((fbytes = fread(buffer.data(), 1, bufferSize, infile)) > 0)
             {
                 _observer.onProgress(offset / pageSize, numPages);
                 
                 if (fbytes < bufferSize)
                 {
-                    memset(buffer + fbytes, 0, bufferSize - fbytes);
+                    memset(buffer.data() + fbytes, 0, bufferSize - fbytes);
                     fbytes = (fbytes + pageSize - 1) / pageSize * pageSize;
                 }
                 
-                _flash->loadBuffer(buffer, fbytes);
+                _flash->loadBuffer(buffer.data(), fbytes);
                 _flash->writeBuffer(foffset + offset, fbytes);
                 offset += fbytes;                
             }
@@ -132,14 +132,14 @@ Flasher::write(const char* filename, uint32_t foffset)
         }
         else
         {
-            uint8_t buffer[pageSize];
+            std::vector<uint8_t> buffer(pageSize);
             uint32_t pageOffset = foffset / pageSize;
 
-            while ((fbytes = fread(buffer, 1, pageSize, infile)) > 0)
+            while ((fbytes = fread(buffer.data(), 1, pageSize, infile)) > 0)
             {
                 _observer.onProgress(pageNum, numPages);
 
-                _flash->loadBuffer(buffer, fbytes);
+                _flash->loadBuffer(buffer.data(), fbytes);
                 _flash->writePage(pageOffset + pageNum);
 
                 pageNum++;
@@ -164,8 +164,8 @@ Flasher::verify(const char* filename, uint32_t& pageErrors, uint32_t& totalError
 {
     FILE* infile;
     uint32_t pageSize = _flash->pageSize();
-    uint8_t bufferA[pageSize];
-    uint8_t bufferB[pageSize];
+    std::vector<uint8_t> bufferA(pageSize);
+    std::vector<uint8_t> bufferB(pageSize);
     uint32_t pageNum = 0;
     uint32_t numPages;
     uint32_t pageOffset;
@@ -200,7 +200,7 @@ Flasher::verify(const char* filename, uint32_t& pageErrors, uint32_t& totalError
 
         _observer.onStatus("Verify %ld bytes of flash\n", fsize);
 
-        while ((fbytes = fread(bufferA, 1, pageSize, infile)) > 0)
+        while ((fbytes = fread(bufferA.data(), 1, pageSize, infile)) > 0)
         {
             byteErrors = 0;
             
@@ -215,7 +215,7 @@ Flasher::verify(const char* filename, uint32_t& pageErrors, uint32_t& totalError
                 
                 if (flashCrc != calcCrc)
                 {
-                    _flash->readPage(pageOffset + pageNum, bufferB);
+                    _flash->readPage(pageOffset + pageNum, bufferB.data());
 
                     for (uint32_t i = 0; i < fbytes; i++)
                     {
@@ -226,7 +226,7 @@ Flasher::verify(const char* filename, uint32_t& pageErrors, uint32_t& totalError
             }
             else
             {
-                _flash->readPage(pageOffset + pageNum, bufferB);
+                _flash->readPage(pageOffset + pageNum, bufferB.data());
 
                 for (uint32_t i = 0; i < fbytes; i++)
                 {
@@ -267,7 +267,7 @@ Flasher::read(const char* filename, uint32_t fsize, uint32_t foffset)
 {
     FILE* outfile;
     uint32_t pageSize = _flash->pageSize();
-    uint8_t buffer[pageSize];
+    std::vector<uint8_t> buffer(pageSize);
     uint32_t pageNum = 0;
     uint32_t pageOffset;
     uint32_t numPages;
@@ -297,11 +297,11 @@ Flasher::read(const char* filename, uint32_t fsize, uint32_t foffset)
         {
             _observer.onProgress(pageNum, numPages);
 
-            _flash->readPage(pageOffset + pageNum, buffer);
+            _flash->readPage(pageOffset + pageNum, buffer.data());
 
             if (pageNum == numPages - 1 && fsize % pageSize > 0)
                 pageSize = fsize % pageSize;
-            fbytes = fwrite(buffer, 1, pageSize, outfile);
+            fbytes = fwrite(buffer.data(), 1, pageSize, outfile);
             if (fbytes != pageSize)
                 throw FileShortError();
         }

--- a/src/PortFactory.h
+++ b/src/PortFactory.h
@@ -48,7 +48,7 @@ public:
     virtual SerialPort::Ptr create(const std::string& name, bool isUsb) = 0;
 };
 
-#if defined(__WIN32__)
+#if defined(__WIN32__) || defined(WIN32)
 #include "WinPortFactory.h"
 typedef WinPortFactory PortFactory;
 #elif defined(__linux__)

--- a/src/PosixSerialPort.cpp
+++ b/src/PosixSerialPort.cpp
@@ -30,12 +30,16 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <termios.h>
 #include <errno.h>
 #include <sys/ioctl.h>
+#if defined(__WIN32__) || defined(WIN32)
+#include "usleep.h"
+#else
+#include <unistd.h>
+#endif
 
 #include <string>
 

--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -33,8 +33,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <ctype.h>
-#include <unistd.h>
 #include <errno.h>
+#if defined(__WIN32__) || defined(WIN32)
+#include "usleep.h"
+#else
+#include <unistd.h>
+#endif
 
 using namespace std;
 

--- a/src/WinPortFactory.cpp
+++ b/src/WinPortFactory.cpp
@@ -26,6 +26,8 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ///////////////////////////////////////////////////////////////////////////////
+#include <vector>
+
 #include "WinPortFactory.h"
 #include "WinSerialPort.h"
 
@@ -102,14 +104,14 @@ WinPortFactory::begin()
     if (size < 1)
         return error();
 
-    GUID guids[size];
+    std::vector<GUID> guids(size);
 
-    if (!SetupDiClassGuidsFromNameA("Ports", guids, size * sizeof(GUID), &size))
+    if (!SetupDiClassGuidsFromNameA("Ports", guids.data(), size * sizeof(GUID), &size))
     {
         return error();
     }
 
-    _devInfo = SetupDiGetClassDevs(guids, NULL, NULL, DIGCF_PRESENT);
+    _devInfo = SetupDiGetClassDevs(guids.data(), NULL, NULL, DIGCF_PRESENT);
     if(_devInfo == INVALID_HANDLE_VALUE)
         return error();
 

--- a/src/WinPortFactory.h
+++ b/src/WinPortFactory.h
@@ -50,7 +50,7 @@ public:
     SerialPort::Ptr create(const std::string& name, bool isUsb);
 
 private:
-    typedef DWORD WINAPI (*CM_Open_DevNode_Key)(DWORD, DWORD, DWORD, DWORD, ::PHKEY, DWORD);
+    typedef DWORD (WINAPI *CM_Open_DevNode_Key)(DWORD, DWORD, DWORD, DWORD, ::PHKEY, DWORD);
 
     HDEVINFO _devInfo;
     HINSTANCE _cfgMgr;

--- a/src/usleep.h
+++ b/src/usleep.h
@@ -1,0 +1,8 @@
+#include <chrono>
+#include <thread>
+
+// Replacement for sleep
+void inline
+usleep(int length) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(length));
+}


### PR DESCRIPTION
This work comes out of building a Bossa frontend for Node (sptgps/bossajs), which can only compile Windows code using MSVC.

Specific changes are no polyfill for `unistd.h`, different token order for `typedef` (I haven't tested this works with mingw) and no variable length arrays.