### PR TITLE
Added a 'bossac' target to make only cli version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,7 @@ BOSSASH_LIBS=-lreadline $(COMMON_LIBS)
 # Main targets
 #
 all: $(BINDIR)/bossa$(EXE) $(BINDIR)/bossac$(EXE) $(BINDIR)/bossash$(EXE)
+bossac: $(BINDIR)/bossac$(EXE)
 
 #
 # Common rules


### PR DESCRIPTION
'make' only supports making all targets, which requires installing superfluous libs if all you want is the cli version.