### PR TITLE
Add some error reporting so a user has some idea where the protocol failed

### DIFF
--- a/src/CmdOpts.cpp
+++ b/src/CmdOpts.cpp
@@ -133,7 +133,26 @@ CmdOpts::parse()
             switch (_opts[optIdx].arg.type)
             {
             case ArgInt:
-                *_opts[optIdx].arg.value.intPtr = strtol(optarg, NULL, 0);
+		{
+		    char*  end_p;
+		    *_opts[optIdx].arg.value.intPtr = strtol(optarg, &end_p, 0);
+		    if (end_p == optarg)
+		    {
+			// Invalid number, see if "false" or "true" was passed.
+			// Older Arduino IDEs use "-U true" instead of --usb-port=1.
+			// This allows platform.txt to be modified to pass --usb-port=true on these versions.
+			if (strcmp(optarg, "false") == 0)
+			    *_opts[optIdx].arg.value.intPtr = 0;
+			else if (strcmp(optarg, "true") == 0)
+			    *_opts[optIdx].arg.value.intPtr = 1;
+			else
+			{
+			    fprintf(stderr, "Invalid number %s\n", optarg);
+			    usage(stderr);
+			    exit(1);
+			}
+		    }
+		}
                 break;
             default:
             case ArgString:

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -373,7 +373,7 @@ CommandConnect::invoke(char* argv[], int argc)
 
     if (!_samba.connect(_portFactory.create(argv[1])))
     {
-        printf("No device found on %s\n", argv[1]);
+        printf("Can't connect to run commands on device found on %s\n", argv[1]);
         _connected = false;
         return;
     }

--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -176,7 +176,6 @@ void
 Samba::disconnect()
 {
     _port->close();
-    _port.release();
 }
 
 void

--- a/src/Samba.h
+++ b/src/Samba.h
@@ -39,9 +39,10 @@
 
 class SambaError : public std::exception
 {
+	const char*	_operation;
 public:
-    SambaError() : exception() {};
-    const char* what() const throw() { return "SAM-BA operation failed"; }
+    SambaError(const char* operation) : exception(), _operation(operation) {};
+    const char* what() const throw() { return _operation; }
 };
 
 

--- a/src/SerialPort.h
+++ b/src/SerialPort.h
@@ -73,7 +73,7 @@ public:
 
     virtual std::string name() const { return _name; }
 
-    typedef std::unique_ptr<SerialPort> Ptr;
+    typedef std::shared_ptr<SerialPort> Ptr;
 
 protected:
     std::string _name;

--- a/src/bossac.cpp
+++ b/src/bossac.cpp
@@ -376,13 +376,20 @@ main(int argc, char* argv[])
         }
 
         bool res;
+	SerialPort::Ptr port;
         if (config.usbPort)
-            res = samba.connect(portFactory.create(config.portArg, config.usbPortArg != 0));
+            port = portFactory.create(config.portArg, config.usbPortArg != 0);
         else
-            res = samba.connect(portFactory.create(config.portArg));
+            port = portFactory.create(config.portArg);
+	if (!port)
+	{
+            fprintf(stderr, "bossac: No such port: %s\n", config.portArg.c_str());
+            return 1;
+	}
+	res = samba.connect(port);
         if (!res)
         {
-            fprintf(stderr, "No device found on %s\n", config.portArg.c_str());
+            fprintf(stderr, "bossac: Can't connect to port found on %s. Check it has a bootloader installed\n", config.portArg.c_str());
             return 1;
         }
 


### PR DESCRIPTION
If _bossac_ cannot open the TTY device, or if it fails to handshake with the bootloader, or if some later step in the protocol fails, it emits the exact same error message: "No device found on ...". This is unacceptable - a failure should always indicate the failure context.

In order to be able to use this _bossac_ with deployed Arduino versions, it must accept the _true_ or _false_ argument provided from _platform.txt_ to the "-U" argument, not just the 0 or 1 integer value. By allowing false(=0) and true(=1) as a parameter to an integer argument, this version of bossa can be used with older Arduino versions (by editing platform.txt to say *--usb-port={upload.native_usb}*).

Note that it's also necessary to pass *--offset=0x2000* or the chip-erase kills the bootloader  and the subsequent write fails (and it just reports *No device found*) - which is why I started this journey in the first place!