### PR TITLE
Fix CRC calculation on verify for crc-capable bootloaders

### DIFF
--- a/src/Flasher.cpp
+++ b/src/Flasher.cpp
@@ -170,7 +170,6 @@ Flasher::verify(const char* filename, uint32_t& pageErrors, uint32_t& totalError
     uint32_t numPages;
     uint32_t pageOffset;
     uint32_t byteErrors = 0;
-    uint16_t calcCrc = 0;
     uint16_t flashCrc;
     long fsize;
     size_t fbytes;
@@ -208,6 +207,7 @@ Flasher::verify(const char* filename, uint32_t& pageErrors, uint32_t& totalError
 
             if (_samba.canChecksumBuffer())
             {
+                uint16_t calcCrc = 0;
                 for (uint32_t i = 0; i < fbytes; i++)
                     calcCrc = _samba.checksumCalc(bufferA[i], calcCrc);
                 


### PR DESCRIPTION
The calculated CRC accumulator must be reset to 0 after each page. Previously the latest result was retained leading to incorrect crc for all the pages after the first one.

This bug won't lead to a verify error (so it may not be the cause of #96 IMHO), because the page was compared anyway with a direct read if the CRC fails, but it degrades performance due to the slow byte-by-byte comparison.
