### PR TITLE
Wait for EEFC flash to complete operations before reseting

### DIFF
--- a/src/EefcFlash.cpp
+++ b/src/EefcFlash.cpp
@@ -272,6 +272,7 @@ EefcFlash::writeOptions()
         waitFSR();
         writeFCR0(EEFC_FCMD_SGPB, 0);
     }
+    waitFSR();  // Verify that all flash operations have completed
 }
 
 void


### PR DESCRIPTION
For an Arduino Due with EEFC flash, setting the boot flash bit doesn't complete before a reset is performed. This makes it impossible to get the SAM device out of bootloader mode. Adding a simple check that flash operations are done after committing them fixes the issue.

Note, to program my Due from Ubuntu also requires #78 to get the 1200 baud reset working.