### PR TITLE
makefile: allow for version override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #
 # Version
 #
-VERSION=$(shell git describe --tags --dirty)
+VERSION ?= $(shell git describe --tags --dirty)
 WXVERSION=3.0
 
 #


### PR DESCRIPTION
I maintain the [AUR package for BOSSA](https://aur.archlinux.org/packages/bossa/). I received a message from a user today.

> maxbla [1] added the following comment to bossa [2]:
>
> This PKGBUILD fails with `fatal: No names found, cannot describe
> anything.`, which is due to the Makefile from upstream, which contains
> the line `VERSION=$(shell git describe --tags --dirty)`. Because this
> package downloads a .tar.gz of the source, rather than `git clone`ing
> it, git tries to describe the AUR package, which contains no tags.
>
> Suggested fixes: either clone the repository entirely, instead of
> downloading the archive, or patch the makefile to have a static
> `Version` (i.e. `VERSION=1.9.1-1`).
>
> If you no longer wish to receive notifications about this package,
> please go to the package page [2] and select "Disable notifications".
>
> [1] https://aur.archlinux.org/account/maxbla/
> [2] https://aur.archlinux.org/pkgbase/bossa/

This patch allows the user to override the `VERSION` variable in the Makefile via an environment variable, which is useful for those building from tarballs created by GitHub's release tag system, rather than from an actual checkout of the git repository.

I've [got the patch in the AUR package](https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=bossa&id=5c23786a2d32794cc5581bd0b64c4f56a5fad73b), but thought I'd put it upstream as well.

Cheers,
mcoffin