### PR TITLE
Short delay to ensure port is flushed in OS X (and prevent download h…

### DIFF
--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -35,6 +35,7 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <errno.h>
+#include <unistd.h>
 
 using namespace std;
 
@@ -521,6 +522,8 @@ Samba::write(uint32_t addr, const uint8_t* buffer, int size)
     if (_isUsb)
     {
         _port->flush();
+        // Short delay to ensure port is flushed in OS X
+        usleep(5000);       
         writeBinary(buffer, size);
     }
     else


### PR DESCRIPTION
I was running into an occasional download failure on a SAMD51 platform only on OS X.

```Write 184800 bytes to flash (361 pages)

[                              ] 0% (0/361 pages)write(addr=0x20004034,size=0x1000)

SAM-BA operation failed
An error occurred while uploading the sketch
```

After digging in a bit, it appears that occasionally the _port->flush() may not always complete before writeBinary() is called in `Samba::write()`.  This results in an exception and an error during download (as it looks like we're running into the "SAM firmware bug" mentioned in the comments).  

Adding this short delay helps ensure that the flush() command competes before the binary write is called.  After adding this delay, I'm no longer getting occasional download failures.  