### PR TITLE
 add SAMC21 support , and wait ready retry (SAMC21 need 6ms to eerase…

### DIFF
--- a/src/D2xNvmFlash.cpp
+++ b/src/D2xNvmFlash.cpp
@@ -292,7 +292,23 @@ D2xNvmFlash::writePage(uint32_t page)
 void
 D2xNvmFlash::waitReady()
 {
-    while ((readReg(NVM_REG_INTFLAG) & 0x1) == 0);
+   uint32_t ReadR;
+   int count = 0;
+   int maxTries = 3;
+   do{
+       try
+       {
+           ReadR = (readReg(NVM_REG_INTFLAG) & 0x1);
+       }
+       catch(const SambaError& e)
+       {
+           count++;
+           if ( count == maxTries){
+               throw ::SambaError();
+           };
+       }
+
+   }while(ReadR  == 0);
 }
 
 void

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -466,7 +466,38 @@ Device::create()
             _family = FAMILY_SAMD21;
             flashPtr = new D2xNvmFlash(_samba, "ATSAMD21x18", 4096, 64, 0x20004000, 0x20008000) ;
             break;
+        //
+        // SAMC21
+        //
+        case 0x1101000D: //E15A
+        case 0x11010008: //G15A
+        case 0x11010003: //J15A
+            _family = FAMILY_SAMC21;
+            flashPtr = new D2xNvmFlash(_samba, "ATSAMC21x15", 512, 64, 0x20000800, 0x20001000) ;
+            break;  
+        case 0x1101000C: //E16A
+        case 0x11010007: //G16A
+        case 0x11010002: //J16A
+            _family = FAMILY_SAMC21;
+            flashPtr = new D2xNvmFlash(_samba, "ATSAMC21x16", 1024, 64, 0x20001000, 0x20002000) ;
+            break;  
 
+        case 0x1101000B: //E17A
+        case 0x11010006: //G17A
+        case 0x11010021: //N17A
+        case 0x11010001: //J17A
+            _family = FAMILY_SAMC21;
+            flashPtr = new D2xNvmFlash(_samba, "ATSAMC21x17", 2048, 64, 0x20002000, 0x20004000) ;
+            break;  
+
+        case 0x1101000A: //E18A
+        case 0x11010005: //G18A
+        case 0x11010000: //J18A
+        case 0x11010020: //N18A
+            _family = FAMILY_SAMC21;
+            flashPtr = new D2xNvmFlash(_samba, "ATSAMC21x18", 4096, 64, 0x20004000, 0x20008000) ;
+            break;  
+            
         //
         // SAMR21
         //

--- a/src/Device.h
+++ b/src/Device.h
@@ -64,6 +64,8 @@ public:
 
         FAMILY_SAM9XE,
 
+        FAMILY_SAMC21,
+        
         FAMILY_SAMD21,
         FAMILY_SAMR21,
         FAMILY_SAML21,


### PR DESCRIPTION
- Add SAMC21 Support tested with Atmel SAMC21 XplainedPro.
- Add waitready retry , because the samc21 need 6ms to erase page.

(According to ka-long)