### PR TITLE
Add support for ATSAMD21 D and L variants

### DIFF
--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -435,13 +435,16 @@ Device::create()
         case 0x10010027: // E15B
         case 0x10010056: // E15B WLCSP
         case 0x10010063: // E15C WLCSP
+        case 0x1001003f: // E15L
             _family = FAMILY_SAMD21;
             flashPtr = new D2xNvmFlash(_samba, "ATSAMD21x15", 512, 64, 0x20000800, 0x20001000) ;
             break;
 
         case 0x10010002: // J16A
         case 0x10010007: // G16A
+        case 0x10010057: // G16L
         case 0x1001000c: // E16A
+        case 0x1001003e: // E16L
         case 0x10010020: // J16B
         case 0x10010023: // G16B
         case 0x10010026: // E16B
@@ -454,7 +457,13 @@ Device::create()
         case 0x10010001: // J17A
         case 0x10010006: // G17A
         case 0x1001000b: // E17A
+        case 0x10010094: // E17D
+        case 0x10010095: // E17D WLCSP
+        case 0x10010097: // E17L
         case 0x10010010: // G17A WLCSP
+        case 0x10010093: // G17D
+        case 0x10010096: // G17L
+        case 0x10010092: // J17D
             _family = FAMILY_SAMD21;
             flashPtr = new D2xNvmFlash(_samba, "ATSAMD21x17", 2048, 64, 0x20002000, 0x20004000) ;
             break;


### PR DESCRIPTION
Added SAMD21 D and L variants. Specified in [Errata DS80000760D](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-D21-Family-Silicon-Errata-and-DataSheet-Clarification-DS80000760D.pdf).

Tested only with SAMD21E17D
