### PR TITLE
PosixSerialPort: Add missing include

### DIFF
--- a/src/PosixSerialPort.cpp
+++ b/src/PosixSerialPort.cpp
@@ -36,6 +36,7 @@
 #include <termios.h>
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
 
 #include <string>
 


### PR DESCRIPTION
#### Contribution Description

`select()` is declared in `<sys/select.h>`. This PR adds the missing `#include`.

#### Testing

Compilation should now work on non-glibc OS. E.g. Alpine Linux.

OR

The [man page](https://linux.die.net/man/2/select) of `select()` also states the required headers.