### PR TITLE
Allow overriding the OS to extend cross-compile abilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ INSTALLDIR=install
 #
 # Determine OS
 #
-OS:=$(shell uname -s | cut -c -7)
+OS?=$(shell uname -s | cut -c -7)
 
 #
 # Windows rules


### PR DESCRIPTION
Allow override OS to support cross-compile compilation if build OS
adn host OS are differnet (e.g. build on MacOS for Linux)

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>