### PR TITLE
src/PosixSerialPort.cpp: fix missing include

### DIFF
--- a/src/PosixSerialPort.cpp
+++ b/src/PosixSerialPort.cpp
@@ -36,6 +36,7 @@
 #include <termios.h>
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <sys/select.h>
 
 #include <string>
 


### PR DESCRIPTION
`select()`, `fd_set`, `FD_ZERO()`, `FD_SET()`, and `FD_ISSET()` require an `#include <sys/select.h>` that previously was missing.

E.g. see `man 2 select`:

> ### NAME
> select, pselect, FD_CLR, FD_ISSET, FD_SET, FD_ZERO - synchronous I/O multiplexing
> 
> ### SYNOPSIS
>        #include <sys/select.h>
> 
>        int select(int nfds, fd_set *restrict readfds,
>                   fd_set *restrict writefds, fd_set *restrict exceptfds,
>                   struct timeval *restrict timeout);
> 
>        void FD_CLR(int fd, fd_set *set);
>        int  FD_ISSET(int fd, fd_set *set);
>        void FD_SET(int fd, fd_set *set);
>        void FD_ZERO(fd_set *set);

glibc is pretty forgiving about missing `#include`s, as it will always include an insane amount of headers indirectly. Other standard C libs follow the standard more closely.