### PR TITLE
Fix build with clang -Wunqualified-std-cast-call

### DIFF
--- a/src/Samba.cpp
+++ b/src/Samba.cpp
@@ -141,7 +141,7 @@ Samba::init()
 bool
 Samba::connect(SerialPort::Ptr port, int bps)
 {
-    _port = move(port);
+    _port = std::move(port);
 
     // Try to connect at a high speed if USB
     _isUsb = _port->isUsb();


### PR DESCRIPTION
This warning is enabled by default since clang 15. This fixes a build error with those recent versions of clang because BOSSA builds with `-Werror`.